### PR TITLE
Change file retrieval to getMarkdownFiles method

### DIFF
--- a/RAGService.ts
+++ b/RAGService.ts
@@ -1023,7 +1023,7 @@ export class RAGService {
 			await this.ensureEmbeddingConnection();
 			
 			// Get all markdown files
-			const files = this.app.vault.getFiles();
+			const files = this.app.vault.getMarkdownFiles();
 			
 			LoggingUtility.log(`Starting to analyze ${files.length} markdown files for changes`);
 			
@@ -1158,7 +1158,7 @@ export class RAGService {
 				LoggingUtility.log('Starting image processing phase...');
 				
 				// Get all files in the vault first for debugging
-				const allFiles = this.app.vault.getFiles();
+				const allFiles = this.app.vault.getMarkdownFiles();
 				LoggingUtility.log(`Total files in vault during indexing: ${allFiles.length}`);
 				
 				// Get all image files in the vault


### PR DESCRIPTION
this fixes an issue where the plugin attempted to feed all files indiscriminately, even images, as text to the embedding server, vastly and needlessly increasing load/processing time.

the changes within this PR request, although very small / simple, change this. now the plugin simply attempts to feed markdown files specifically to the embedding server and nothing else.

for me, within my current main vault, it reduced the generated chunks from 2.5 million to 150,000, effectively eliminating **94%** of my chunk processing load / wait time.
