### PR TITLE
fix: correct pluralization logic in used notes header

### DIFF
--- a/ChatView.ts
+++ b/ChatView.ts
@@ -648,7 +648,7 @@ export class ChatView extends ItemView {
 			
 			// Create header text
 			const headerText = notesHeader.createEl('span', {
-				text: `📚 Used ${deduplicatedNotes.length} note${deduplicatedNotes.length > 1 ? 's' : ''} as context:`
+				text: `📚 Used ${deduplicatedNotes.length} note${deduplicatedNotes.length !== 1 ? 's' : ''} as context:`
 			});
 			
 			// Create toggle link


### PR DESCRIPTION
This PR fixes a minor pluralization typo in the ChatView. The previous logic used `length > 1` which would result in '0 note' instead of '0 notes' if no notes were used. Changed to `length !== 1` to correctly handle zero and plural cases.