### PR TITLE
🧹 fix: Improve error handling for migration rollbacks

### DIFF
--- a/src/db/MigrationRunner.ts
+++ b/src/db/MigrationRunner.ts
@@ -44,7 +44,11 @@ export class MigrationRunner {
                     LoggingUtility.log(`Migration version ${migration.version} applied successfully`);
                 } catch (error) {
                     LoggingUtility.error(`Error during migration ${migration.version}:`, error);
-                    db.run("ROLLBACK");
+                    try {
+                        db.run("ROLLBACK");
+                    } catch (rollbackError) {
+                        LoggingUtility.error(`Failed to rollback migration ${migration.version}:`, rollbackError);
+                    }
                     throw error;
                 }
             } catch (error) {


### PR DESCRIPTION
🎯 **What:** The `db.run("ROLLBACK")` call in `src/db/MigrationRunner.ts` was not wrapped in a `try...catch` block. This meant that if the rollback operation itself failed, the exception thrown would mask the original exception that caused the migration to fail.

💡 **Why:** This change wraps the `db.run("ROLLBACK")` call in a `try...catch` block. If the rollback fails, the error is logged using `LoggingUtility.error`, and the original error from the migration failure is properly re-thrown. This prevents swallowing exceptions and significantly improves observability and debugging when migrations fail.

✅ **Verification:**
- Ran `npm run test` successfully. All 35 tests across 5 test suites passed.
- Code review was positive and confirmed the fix successfully improved observability without negative side effects.

✨ **Result:** A safer migration runner that preserves and logs both the original migration failure and any subsequent rollback failures.

---
*PR created automatically by Jules for task [30274543415928085](https://jules.google.com/task/30274543415928085) started by @gabosgab*